### PR TITLE
Dockerize Flask dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+venv/
+ENV/
+*.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,23 @@ Simple Flask dashboard for monitoring a Monero node via RPC.
 4. Open `http://localhost:5000` in your browser.
 
 
+
+## Docker
+
+You can run the dashboard in a container.
+
+Build the image:
+
+```bash
+docker build -t dashero .
+```
+
+Run the container (mounting your `config.py` for configuration):
+
+```bash
+docker run --rm -p 5000:5000 \
+    -v $(pwd)/config.py:/app/config.py \
+    dashero
+```
+
+Then open `http://localhost:5000` in your browser.


### PR DESCRIPTION
## Summary
- add Dockerfile to run the dashboard in a container
- add .dockerignore
- document Docker build and run steps

## Testing
- `python -m py_compile app.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6856de64c160832290f872e47d6409c1